### PR TITLE
Update `openssl` command to follow recommandation

### DIFF
--- a/cryptr.bash
+++ b/cryptr.bash
@@ -46,9 +46,9 @@ cryptr_encrypt() {
 
   if [[ ! -z "${CRYPTR_PASSWORD}" ]]; then
     echo "[notice] using environment variable CRYPTR_PASSWORD for the password"
-    openssl $OPENSSL_CIPHER_TYPE -salt -in "$_file" -out "$_file".aes -pass env:CRYPTR_PASSWORD
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "$_file".aes -pass env:CRYPTR_PASSWORD
   else
-    openssl $OPENSSL_CIPHER_TYPE -salt -in "$_file" -out "$_file".aes
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "$_file".aes
   fi
 }
 
@@ -61,9 +61,9 @@ local _file="$1"
 
   if [[ ! -z "${CRYPTR_PASSWORD}" ]]; then
     echo "[notice] using environment variable CRYPTR_PASSWORD for the password"
-    openssl $OPENSSL_CIPHER_TYPE -d -salt -in "$_file" -out "${_file%\.aes}" -pass env:CRYPTR_PASSWORD
+    openssl $OPENSSL_CIPHER_TYPE -d -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}" -pass env:CRYPTR_PASSWORD
   else
-    openssl $OPENSSL_CIPHER_TYPE -d -salt -in "$_file" -out "${_file%\.aes}"
+    openssl $OPENSSL_CIPHER_TYPE -d -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}"
   fi
 }
 

--- a/cryptr.bash
+++ b/cryptr.bash
@@ -46,9 +46,9 @@ cryptr_encrypt() {
 
   if [[ ! -z "${CRYPTR_PASSWORD}" ]]; then
     echo "[notice] using environment variable CRYPTR_PASSWORD for the password"
-    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "$_file".aes -pass env:CRYPTR_PASSWORD
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}" -pass env:CRYPTR_PASSWORD
   else
-    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "$_file".aes
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}"
   fi
 }
 


### PR DESCRIPTION
Hello,

openssl recommand to use a derivation function for encryption with password.

```
*** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
```

You can found the documentation about PBKDF2 here : https://en.wikipedia.org/wiki/PBKDF2 and https://www.openssl.org/docs/manmaster/man1/openssl-enc.html

Thanks for the script. It's really useful :smiley: 