### PR TITLE
Append extension during encryption

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,2 +1,3 @@
 - Justin Keller ([nodesocket](https://github.com/nodesocket))
 - Manuel Wildauer ([int9h](https://github.com/int9h))
+- Adam Daniels ([adam12](https://github.com/adam12))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Append `.aes` file extension instead of substituting when encrypting
+
 ## 2.1.1 - *3/25/2019*
 
 - Updated the notice text when using environment variable `CRYPTR_PASSWORD` for the password.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-## Unreleased
+## 2.1.2 - *7/10/2020*
 
 - Append `.aes` file extension instead of substituting when encrypting
 

--- a/cryptr.bash
+++ b/cryptr.bash
@@ -18,7 +18,7 @@
 
 set -eo pipefail; [[ $TRACE ]] && set -x
 
-readonly VERSION="2.1.1"
+readonly VERSION="2.1.2"
 readonly OPENSSL_CIPHER_TYPE="aes-256-cbc"
 
 cryptr_version() {

--- a/cryptr.bash
+++ b/cryptr.bash
@@ -46,9 +46,9 @@ cryptr_encrypt() {
 
   if [[ ! -z "${CRYPTR_PASSWORD}" ]]; then
     echo "[notice] using environment variable CRYPTR_PASSWORD for the password"
-    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}" -pass env:CRYPTR_PASSWORD
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file}.aes" -pass env:CRYPTR_PASSWORD
   else
-    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file%\.aes}"
+    openssl $OPENSSL_CIPHER_TYPE -salt -pbkdf2 -in "$_file" -out "${_file}.aes"
   fi
 }
 


### PR DESCRIPTION
Source files are currently being overwritten with the encrypted contents. If you then attempt to decrypt these files without appending the `.aes` file extension, you end up with a 0 byte file, losing both encrypted and decrypted versions.

Append the file extension instead of trying to remove it during the encryption process.